### PR TITLE
1.0.0.7: log file was still outputting as timestamped version despite…

### DIFF
--- a/SRTPluginManager/App.xaml.cs
+++ b/SRTPluginManager/App.xaml.cs
@@ -21,11 +21,7 @@ namespace SRTPluginManager
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
-#if DEBUG
-            logFS = new FileStream(string.Format(@"SRTPluginManager_{0}.log", DateTime.UtcNow.ToString("yyyy-MM-dd_HH-mm-ss-fffffff")), FileMode.Create, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
-#else
             logFS = new FileStream(@"SRTPluginManager.log", FileMode.Create, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
-#endif
             logSW = new StreamWriter(logFS, Encoding.UTF8) { AutoFlush = true };
 
             logSW.LogInfoWriteLine("Evaluating command-line arguments...");

--- a/SRTPluginManager/SRTPluginManager.csproj
+++ b/SRTPluginManager/SRTPluginManager.csproj
@@ -10,8 +10,8 @@
     <Copyright>Copyright © 2021 VideoGameRoulette</Copyright>
     <Product>SRT Host Plugin Manager</Product>
     <Description>A plugin manager for SRT Host.</Description>
-    <Version>1.0.0.6</Version>
-    <FileVersion>1.0.0.6</FileVersion>
+    <Version>1.0.0.7</Version>
+    <FileVersion>1.0.0.7</FileVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <DebugType>embedded</DebugType>
     <CopyDestionationPath>$(SolutionDir)..\..\..\Squirrelies\SRTHost\SRTHost\bin\$(Configuration)\net5.0-windows\</CopyDestionationPath>


### PR DESCRIPTION
… explicit preprocessor directive for DEBUG symbol and publish profile EXPLICITLY defined as Release. G R O W L