### PR TITLE
Fix a flaw in the newer 1.0.0.8 update logic that would cause a Direc…

### DIFF
--- a/SRTPluginManager/Core/Utilities.cs
+++ b/SRTPluginManager/Core/Utilities.cs
@@ -152,15 +152,19 @@ namespace SRTPluginManager.Core
 
             if (!isSRT)
             {
-                // Save plugin config file.
-                FileInfo configFile = new DirectoryInfo(Path.Combine(destination, pluginName)).EnumerateFiles(string.Format("{0}.cfg", pluginName), SearchOption.TopDirectoryOnly).FirstOrDefault();
+                DirectoryInfo pluginDirectory = new DirectoryInfo(Path.Combine(destination, pluginName));
+                if (pluginDirectory.Exists)
+                {
+                    // Save plugin config file.
+                    FileInfo configFile = pluginDirectory.EnumerateFiles(string.Format("{0}.cfg", pluginName), SearchOption.TopDirectoryOnly).FirstOrDefault();
 
-                // If the config file exists, copy it to the temp folder until after the delete and unzip completes.
-                if (configFile != default && configFile.Exists)
-                    configFile.CopyTo(Path.Combine(TempFolderPath, configFile.Name), true);
+                    // If the config file exists, copy it to the temp folder until after the delete and unzip completes.
+                    if (configFile != default && configFile.Exists)
+                        configFile.CopyTo(Path.Combine(TempFolderPath, configFile.Name), true);
 
-                // Delete the plugin folder to ensure a clean slate.
-                Directory.Delete(Path.Combine(destination, pluginName), true);
+                    // Delete the plugin folder to ensure a clean slate.
+                    pluginDirectory.Delete(true);
+                }
             }
 
             ZipFile.ExtractToDirectory(file, destination, true);


### PR DESCRIPTION
…toryNotFoundException when the plugin directory didn't exist (new installs).